### PR TITLE
Fix Gradle version >= 7.0.0

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,6 +1,8 @@
 apply plugin: 'com.android.library'
 
 android {
+    compileSdkVersion 23
+    buildToolsVersion "23.0.1"
 
     defaultConfig {
         minSdkVersion 16

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,8 +1,8 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 23
-    buildToolsVersion "23.0.1"
+    compileSdkVersion 33
+    buildToolsVersion "33.0.0"
 
     defaultConfig {
         minSdkVersion 16

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -13,6 +13,6 @@ android {
 }
 
 dependencies {
-    classpath('com.google.zxing:core:3.2.1')
-    classpath("com.facebook.react:react-native:+")  // From node_modules
+    implementation 'com.google.zxing:core:3.2.1'
+    implementation "com.facebook.react:react-native:+"  // From node_modules
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -13,6 +13,6 @@ android {
 }
 
 dependencies {
-    compile 'com.google.zxing:core:3.2.1'
-    compile "com.facebook.react:react-native:+"  // From node_modules
+    classpath('com.google.zxing:core:3.2.1')
+    classpath("com.facebook.react:react-native:+")  // From node_modules
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,17 +1,5 @@
 apply plugin: 'com.android.library'
 
-android {
-    compileSdkVersion 23
-    buildToolsVersion "23.0.1"
-
-    defaultConfig {
-        minSdkVersion 16
-        targetSdkVersion 23
-        versionCode 1
-        versionName "1.0"
-    }
-}
-
 dependencies {
     implementation 'com.google.zxing:core:3.2.1'
     implementation "com.facebook.react:react-native:+"  // From node_modules

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,11 +1,15 @@
 apply plugin: 'com.android.library'
 
+def getExtOrDefault(name, defaultValue) {
+    return rootProject.ext.has(name) ? rootProject.ext.get(name) : defaultValue
+}
+
 android {
-    compileSdkVersion 33
-    buildToolsVersion "33.0.0"
+    compileSdkVersion getExtOrDefault('compileSdkVersion', 23)
+    buildToolsVersion getExtOrDefault('buildToolsVersion', "23.0.1")
 
     defaultConfig {
-        minSdkVersion 16
+        minSdkVersion getExtOrDefault('minSdkVersion', 16)
     }
 }
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,5 +1,12 @@
 apply plugin: 'com.android.library'
 
+android {
+
+    defaultConfig {
+        minSdkVersion 16
+    }
+}
+
 dependencies {
     implementation 'com.google.zxing:core:3.2.1'
     implementation "com.facebook.react:react-native:+"  // From node_modules


### PR DESCRIPTION
The file android/build.gradle isn't compatible with gradle >= 7.0.0 because of use of compile.
I added verification of ext sdk version to match differents environments.